### PR TITLE
Correct truncation of text in solution template

### DIFF
--- a/code/40-cloudformation-features/05-lab04-Mapping.yaml
+++ b/code/40-cloudformation-features/05-lab04-Mapping.yaml
@@ -26,7 +26,7 @@ Parameters:
     AllowedValues:
       - test
       - prod
-    Constrai
+    ConstraintDescription: 'Specify either test or prod.'
     
 # Add a Mappings section here!
 


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
This change corrects the Mapping Solution template. A `ConstraintDescription` key had been truncated, rendering the template invalid. This PR adds the original text back

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
