### PR TITLE
Fix formatting of note

### DIFF
--- a/workshop/content/20-prerequisites/100-account.md
+++ b/workshop/content/20-prerequisites/100-account.md
@@ -39,4 +39,6 @@ here](https://portal.aws.amazon.com/billing/signup).
 
     ![](/20-prerequisites/new-user-3.png)
 
-    ***Important:** Keep this browser window open for the next step or take a note of the access key ID and secret access key.*
+{{% notice note %}}
+Important: Keep this browser window open for the next step or take a note of the access key ID and secret access key.
+{{% /notice %}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes the formatting of the final paragraph in the prerequisites/account section. 
Previously both the sentence and the **important** were made bold. This did not render correctly.
I've converted it to a note.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
