### PR TITLE
Add notice

### DIFF
--- a/workshop/content/20-prerequisites/300-editor.md
+++ b/workshop/content/20-prerequisites/300-editor.md
@@ -13,3 +13,8 @@ To install VS Code, use your operating system's package manager (e.g. `brew cask
 We recommend you install the [AWS CloudFormation Linter](https://github.com/aws-cloudformation/cfn-python-lint).  A [linter](https://en.wikipedia.org/wiki/Lint_(software)) will proactively flag basic errors in your CloudFormation templates before you deploy them.
 
 If you are using Visual Studio Code, you should install the [cfn-lint](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint) plugin.
+
+{{% notice tip %}}
+Note that `cfn-lint` is not installed automatically with the Visual Studio Code  `cfn-lint` extension. 
+Install it seperately following the [installation instructions](https://github.com/aws-cloudformation/cfn-python-lint#install)
+{{% /notice %}}


### PR DESCRIPTION
This notice highlights the seperate installation of cfn-lint required for
the vscode cfn-lint extension

*Issue #, if available:*
NA

*Description of changes:*

The pre-requisite page suggests `cfn-lint` as a useful tool when working with CloudFormation templates. However, it is not clear that the `cfn-lint` tool must be installed in addition to the VS Code extension. 
This PR adds a notice to the Editor pre-requisite page explaining that both must be installed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
