### PR TITLE
Convert code blocks to backtick-style markdown

### DIFF
--- a/workshop/content/20-prerequisites/200-awscli.md
+++ b/workshop/content/20-prerequisites/200-awscli.md
@@ -19,12 +19,16 @@ the **access key ID** and **secret key** you create in [the previous step](../10
 use `us-east-1`, `eu-west-1`, `us-west-2` for example). Preferably use a region
 that doesn't have any resources already deployed into it.
 
-    aws configure
+```shell script
+aws configure
+```
 
 
 And fill in the information from the console:
 
-    AWS Access Key ID [None]: <type key ID here>
-    AWS Secret Access Key [None]: <type access key>
-    Default region name [None]: <choose region (e.g. "us-east-1", "eu-west-1")>
-    Default output format [None]: <leave blank>
+```text
+AWS Access Key ID [None]: <type key ID here>
+AWS Secret Access Key [None]: <type access key>
+Default region name [None]: <choose region (e.g. "us-east-1", "eu-west-1")>
+Default output format [None]: <leave blank>
+```

--- a/workshop/content/20-prerequisites/400-git.md
+++ b/workshop/content/20-prerequisites/400-git.md
@@ -14,7 +14,9 @@ There are two ways to install Git on macOS: using [Xcode](https://developer.appl
 
 1. Open your terminal and run following command:
 
-        xcode-select --install
+    ```shell script
+    xcode-select --install
+    ```
 
 1. Follow the installation steps in the opened software update popup window.
 
@@ -34,7 +36,9 @@ Verify installation by type `git --version` into a terminal.
 1. Open a Command Prompt (or Git Bash if during installation you elected not to use Git from the Windows Command Prompt).
 1. Run the following commands `git --version`
 
-        git --version
+    ```shell script
+    git --version
 
-        # should return similar output
-        git version 2.23.0.windows.1
+    # should return similar output
+    git version 2.23.0.windows.1
+   ```

--- a/workshop/content/20-prerequisites/500-lab-resources.md
+++ b/workshop/content/20-prerequisites/500-lab-resources.md
@@ -8,7 +8,9 @@ The CloudFormation templates can be found in `code/` directory of the `cfn101-wo
 
 1. Clone the repository to your working directory:
 
-        git clone https://github.com/aws-samples/cfn101-workshop
+    ```shell script
+    git clone https://github.com/aws-samples/cfn101-workshop
+    ```
 
     Or Download the ZIP file from [the Github repository page](https://github.com/aws-samples/cfn101-workshop):
 

--- a/workshop/content/20-prerequisites/600-default-vpc.md
+++ b/workshop/content/20-prerequisites/600-default-vpc.md
@@ -24,7 +24,9 @@ First we will check if a default VPC is present or not. We will use the AWS CLI 
 
 1. Copy the code below to your terminal. Make sure to change the `--region` flag to use a region that you are going to be deploying your CloudFormation to.
 
-       aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query "Vpcs[].VpcId" --region eu-west-2
+    ```shell script
+    aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query "Vpcs[].VpcId" --region eu-west-2
+    ```
 
 If the default VPC exists, it will be included here. Assert that `IsDefault` key is `true` and [move to the next step](/30-workshop-part-01/). You can skip the remainder of this section.
 
@@ -32,33 +34,37 @@ If the response is empty `[]` or the VPC is not **default** proceed to the next 
 
 1. Copy the code below to your terminal. Make sure to change the --region flag to use a region that you are going to be deploying your CloudFormation to.
 
-       aws ec2 create-default-vpc --region eu-west-2
+    ```shell script
+    aws ec2 create-default-vpc --region eu-west-2
+    ```
 
     The result will be a new default VPC being created and the response in the terminal will look like the sample below.
 
-       {
-           "Vpc": {
-               "CidrBlock": "172.31.0.0/16",
-               "DhcpOptionsId": "dopt-c1422ea9",
-               "State": "pending",
-               "VpcId": "vpc-088b5ae6628fbf3ac",
-               "OwnerId": "123456789012",
-               "InstanceTenancy": "default",
-               "Ipv6CidrBlockAssociationSet": [],
-               "CidrBlockAssociationSet": [
-                   {
-                       "AssociationId": "vpc-cidr-assoc-0ab2ffabcbe0548bc",
-                       "CidrBlock": "172.31.0.0/16",
-                       "CidrBlockState": {
-                           "State": "associated"
-                       }
-                   }
-               ],
-               "IsDefault": true,
-               "Tags": []
-           }
-       }
-
+    ```json
+    {
+        "Vpc": {
+            "CidrBlock": "172.31.0.0/16",
+            "DhcpOptionsId": "dopt-c1422ea9",
+            "State": "pending",
+            "VpcId": "vpc-088b5ae6628fbf3ac",
+            "OwnerId": "123456789012",
+            "InstanceTenancy": "default",
+            "Ipv6CidrBlockAssociationSet": [],
+            "CidrBlockAssociationSet": [
+                {
+                    "AssociationId": "vpc-cidr-assoc-0ab2ffabcbe0548bc",
+                    "CidrBlock": "172.31.0.0/16",
+                    "CidrBlockState": {
+                        "State": "associated"
+                    }
+                }
+            ],
+            "IsDefault": true,
+            "Tags": []
+        }
+    }
+    ```
+   
    {{% notice note %}}
    If you wish to delete the default VPC again at the end of this workshop you should make a note of the **VpcId** above so that you can be sure to know which one to delete later.
    {{% /notice %}}

--- a/workshop/content/30-workshop-part-01/10-cloudformation-fundamentals/100-template-anatomy.md
+++ b/workshop/content/30-workshop-part-01/10-cloudformation-fundamentals/100-template-anatomy.md
@@ -14,23 +14,25 @@ Throughout this workshop, code samples will use the YAML format. If you prefer t
 
 The following example shows an AWS CloudFormation YAML template structure and its top-level objects:
 
-    AWSTemplateFormatVersion: 'version date' (optional) # version of the CloudFormation template. Only accepted value is '2010-09-09'
+```yaml
+AWSTemplateFormatVersion: 'version date' (optional) # version of the CloudFormation template. Only accepted value is '2010-09-09'
 
-    Description: 'String' (optional) # a text description of the Cloudformation template
+Description: 'String' (optional) # a text description of the Cloudformation template
 
-    Metadata: 'template metadata' (optional) # objects that provide additional information about the template
+Metadata: 'template metadata' (optional) # objects that provide additional information about the template
 
-    Parameters: 'set of parameters' (optional) # a set of inputs used to customize the template
+Parameters: 'set of parameters' (optional) # a set of inputs used to customize the template
 
-    Mappings: 'set of mappings' (optional) # a mapping of keys and associated values
+Mappings: 'set of mappings' (optional) # a mapping of keys and associated values
 
-    Conditions: 'set of conditions' (optional) # conditions that control whether certain resources are created
+Conditions: 'set of conditions' (optional) # conditions that control whether certain resources are created
 
-    Transform: 'set of transforms' (optional) # for serverless applications
+Transform: 'set of transforms' (optional) # for serverless applications
 
-    Resources: 'set of resources' (required) # a components of your infrastructure
+Resources: 'set of resources' (required) # a components of your infrastructure
 
-    Outputs: 'set of outputs' (optional) # values that are returned whenever you view your stack's properties
+Outputs: 'set of outputs' (optional) # values that are returned whenever you view your stack's properties
+```
 
 The only required top-level object is the **Resources** object, which must declare at least one resource. The definition of each of these objects can be found in the online [Template Anatomy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html) documentation.
 

--- a/workshop/content/30-workshop-part-01/10-cloudformation-fundamentals/200-lab-01-stack.md
+++ b/workshop/content/30-workshop-part-01/10-cloudformation-fundamentals/200-lab-01-stack.md
@@ -19,9 +19,11 @@ By the end of this lab, you will be able to:
 1. Open the `01-lab01-StackExample.yaml` file in your code editor.
 1. Here is a sample CloudFormation template that defines an S3 Bucket. It has a single resource that contains the S3 bucket. Copy the code below and save to the `01-lab01-StackExample.yaml` file.
 
-        Resources:
-          S3Bucket:
-            Type: AWS::S3::Bucket
+    ```yaml
+   Resources:
+     S3Bucket:
+       Type: AWS::S3::Bucket
+   ```
 
 1. Open the **[AWS CloudFormation](https://console.aws.amazon.com/cloudformation)** link in a new tab and log in to your AWS account.
 1. Click on **Create stack** (_With new resources (Standard)_ if you have clicked at the top right corner).
@@ -51,12 +53,14 @@ Check out the AWS Documentation for [AWS::S3::Bucket](https://docs.aws.amazon.co
 {{%expand "Want to see the solution?" %}}
 1. Replace the code in your template with the code bellow:
 
-       Resources:
-         S3Bucket:
-           Type: AWS::S3::Bucket
-           Properties:
-             VersioningConfiguration:
-               Status: Enabled
+   ```yaml
+   Resources:
+     S3Bucket:
+       Type: AWS::S3::Bucket
+       Properties:
+         VersioningConfiguration:
+           Status: Enabled
+   ```
 
 1. Update the stack as per demo bellow:
 

--- a/workshop/content/30-workshop-part-01/20-cloudformation-features/100-lab-02-resources.md
+++ b/workshop/content/30-workshop-part-01/20-cloudformation-features/100-lab-02-resources.md
@@ -38,17 +38,19 @@ The _Description_ section enables you to include comments about your template.
 #### Metadata
 You can use the [_Metadata_ section](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html) to include arbitrary JSON or YAML objects. This section is useful for providing information to other tools that interact with your CloudFormation template. For example, when deploying CloudFormation templates via the AWS console, you can improve the experience of users deploying your templates by specify how to order, label and group parameters. This can be done with the [_AWS::CloudFormation::Interface_](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html) key.
 
-    Metadata:
-      AWS::CloudFormation::Interface:
-        ParameterGroups:
-          - Label:
-              default: 'Amazon EC2 Configuration'
-            Parameters:
-              - InstanceType
+```yaml
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: 'Amazon EC2 Configuration'
+        Parameters:
+          - InstanceType
 
-        ParameterLabels:
-          InstanceType:
-            default: 'Type of EC2 Instance'
+    ParameterLabels:
+      InstanceType:
+        default: 'Type of EC2 Instance'
+```
 
 #### Parameters
 _Parameters_ enable you to input custom values to your template each time you create or update a stack.
@@ -64,25 +66,29 @@ AWS CloudFormation supports the following parameter types:
 |[AWS-Specific Parameter Types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-specific-parameter-types)|AWS values such as Amazon VPC IDs.| _AWS::EC2::VPC::Id_ |
 |[SSM Parameter Types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types)|Parameters that correspond to existing parameters in Systems Manager Parameter Store.| _AWS::SSM::Parameter::Value\<AWS::EC2::Image::Id\>_ |
 
-    Parameters:
-      InstanceType:
-        Type: String
-        Default: t2.micro
-        AllowedValues:
-          - t2.micro
-          - t2.small
-        Description: 'Enter t2.micro or t2.small. Default is t2.micro.'
+```yaml
+Parameters:
+  InstanceType:
+    Type: String
+    Default: t2.micro
+    AllowedValues:
+      - t2.micro
+      - t2.small
+    Description: 'Enter t2.micro or t2.small. Default is t2.micro.'
+```
 
 #### Resources
 
 The required _Resources_ section declares the AWS resources that you want to include in the stack. Let's add the EC2 resource to your stack.
 
-    Resources:
-      WebServerInstance:
-        Type: 'AWS::EC2::Instance'
-        Properties:
-          InstanceType: !Ref InstanceType
-          ImageId: <replace with AMI ID ami-xxxxx>
+```yaml
+Resources:
+  WebServerInstance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      InstanceType: !Ref InstanceType
+      ImageId: <replace with AMI ID ami-xxxxx>
+```
 
 The only required property of the EC2 resource type is _ImageId_. Let's find the AMI ID via AWS console:
 
@@ -143,11 +149,13 @@ Check out the [AWS Compute Blog](https://aws.amazon.com/blogs/compute/query-for-
 {{%expand "Want to see the solution?" %}}
 Copy the code below to your terminal. Make sure to change the `--region` flag to use a region that you are deploying your CloudFormation to.
 
-    aws ssm get-parameters \
-    --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 \
-    --query "Parameters[].Value" \
-    --region eu-west-2 \
-    --output text
+```shell script
+aws ssm get-parameters \
+  --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 \
+  --query "Parameters[].Value" \
+  --region eu-west-2 \
+  --output text
+```
 
 ![ami-id-gif](../ami-id.gif)
 {{% /expand %}}

--- a/workshop/content/30-workshop-part-01/20-cloudformation-features/200-lab-03-functions.md
+++ b/workshop/content/30-workshop-part-01/20-cloudformation-features/200-lab-03-functions.md
@@ -35,19 +35,23 @@ In the last lab you have "hard coded" an AMI ID directly into the EC2 Resource p
 
 1. First, create new parameter called `AmiID` and put it in the `Parameters` section of your template.
 
-         AmiID:
-           Type: AWS::EC2::Image::Id
-           Description: 'The ID of the AMI.'
+    ```yaml
+      AmiID:
+        Type: AWS::EC2::Image::Id
+        Description: 'The ID of the AMI.'
+   ```
 
 1. Use the intrinsic function `Ref` to pass the `AmiID` parameter input to the EC2 resource property.
 
-       Resources:
-         WebServerInstance:
-           Type: AWS::EC2::Instance
-           Properties:
-             # Use !Ref function in ImageId property
-             ImageId: !Ref AmiID
-             InstanceType: !Ref InstanceType
+    ```yaml
+    Resources:
+      WebServerInstance:
+        Type: AWS::EC2::Instance
+        Properties:
+          # Use !Ref function in ImageId property
+          ImageId: !Ref AmiID
+          InstanceType: !Ref InstanceType
+   ```
 
 #### Fn::Join
 
@@ -56,15 +60,17 @@ To help you manage your AWS resources, you can optionally assign your own metada
 1. Add property `Tags` to the `Properties` section.
 1. Reference `InstanceType` parameter and add a word _webserver_, delimited with dash `-` to the tags property.
 
-       Resources:
-         WebServerInstance:
-           Type: AWS::EC2::Instance
-           Properties:
-             ImageId: !Ref AmiID
-             InstanceType: !Ref InstanceType
-             Tags:
-               - Key: Name
-                 Value: !Join [ '-', [ !Ref InstanceType, webserver ] ]
+    ```yaml
+    Resources:
+      WebServerInstance:
+        Type: AWS::EC2::Instance
+        Properties:
+          ImageId: !Ref AmiID
+          InstanceType: !Ref InstanceType
+          Tags:
+            - Key: Name
+              Value: !Join [ '-', [ !Ref InstanceType, webserver ] ]
+   ```
 
 #### Update EC2 stack
 
@@ -109,17 +115,19 @@ Check out the AWS Documentation for **[Fn::Sub](https://docs.aws.amazon.com/AWSC
 
 1. Add the `InstanceType` tag to your template.
 
-       Resources:
-         WebServerInstance:
-           Type: AWS::EC2::Instance
-           Properties:
-             ImageId: !Ref AmiID
-             InstanceType: !Ref InstanceType
-             Tags:
-               - Key: Name
-                 Value: !Join [ '-', [ !Ref InstanceType, webserver ] ]
-               - Key: InstanceType
-                 Value: !Sub ${InstanceType}
+    ```yaml
+    Resources:
+      WebServerInstance:
+        Type: AWS::EC2::Instance
+        Properties:
+          ImageId: !Ref AmiID
+          InstanceType: !Ref InstanceType
+          Tags:
+            - Key: Name
+              Value: !Join [ '-', [ !Ref InstanceType, webserver ] ]
+            - Key: InstanceType
+              Value: !Sub ${InstanceType}
+    ```
 
 1. Go to the AWS console and update your CloudFormation Stack.
 1. In the EC2 console, verify that `InstanceType` tag has been created.

--- a/workshop/content/30-workshop-part-01/20-cloudformation-features/300-lab-04-mappings.md
+++ b/workshop/content/30-workshop-part-01/20-cloudformation-features/300-lab-04-mappings.md
@@ -14,18 +14,19 @@ Here is a simplified example of a Mappings section. It contains one Map, `AnExam
 `AnExampleMapping` contains three top level keys, `Key01`, `Key02` and `Key03`. \
 Each top level key contains one or more `Key: Value` pairs.
 
-    Mappings:
-      AnExampleMap:
-        TopLevelKey01:
-          Key01: Value01
-          Key02: Value02
+```yaml
+Mappings:
+  AnExampleMap:
+    TopLevelKey01:
+      Key01: Value01
+      Key02: Value02
 
-        TopLevelKey02:
-          AnotherKey: AnExampleValue
+    TopLevelKey02:
+      AnotherKey: AnExampleValue
 
-        TopLevelKey03:
-          AFinalKey: ADifferentValue
-
+    TopLevelKey03:
+      AFinalKey: ADifferentValue
+```
 
 ### Topics Covered
 In this Lab, you will:
@@ -49,15 +50,17 @@ This section will define two possible environments, `Test` and `Prod`. It will u
 
 In the _Parameters_ section of the template. Replace the `InstanceType` parameter with the code below (you will not need the `InstanceType `parameter anymore. You will use the mapping instead).
 
-    Parameters:
-      EnvironmentType:
-        Description: 'Specify the Environment type of the stack.'
-        Type: String
-        Default: Test
-        AllowedValues:
-          - Test
-          - Prod
-        ConstraintDescription: 'Specify either Test or Prod.'
+```yaml
+Parameters:
+  EnvironmentType:
+    Description: 'Specify the Environment type of the stack.'
+    Type: String
+    Default: Test
+    AllowedValues:
+      - Test
+      - Prod
+    ConstraintDescription: 'Specify either Test or Prod.'
+```
 
 {{% notice note %}}
 Dont forget to remove `InstanceType` from the _ParameterGroups_ and _ParameterLabels_ sections of the template.
@@ -67,34 +70,40 @@ Dont forget to remove `InstanceType` from the _ParameterGroups_ and _ParameterLa
 
 The map contains two top level keys, one for each environment. Each top level key contains a single `InstanceType` second level key.
 
-    Mappings:
-      EnvironmentToInstanceType: # Map Name
-        Test: # Top level key
-          InstanceType: t2.micro # Second level key
-        Prod:
-          InstanceType: t2.small
+```yaml
+Mappings:
+  EnvironmentToInstanceType: # Map Name
+    Test: # Top level key
+      InstanceType: t2.micro # Second level key
+    Prod:
+      InstanceType: t2.small
+```
 
 #### 3. Next, modify the _InstanceType_ property
 
 Using the intrinsic function `Fn::FindInMap`, CloudFormation will lookup the value in the `EnvironmentToInstanceType` map and will return the value back to `InstanceType` property.
 
-    Resources:
-      WebServerInstance:
-        Type: AWS::EC2::Instance
-        Properties:
-          ImageId: !Ref AmiID
-          InstanceType: !FindInMap
-            - EnvironmentToInstanceType # Map Name
-            - !Ref EnvironmentType # Top Level Key
-            - InstanceType # Second Level Key
+```yaml
+Resources:
+  WebServerInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiID
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType # Map Name
+        - !Ref EnvironmentType # Top Level Key
+        - InstanceType # Second Level Key
+```
 
 #### 4. Next, update the _Tags_ property
 
 As you have deleted the `InstanceType` parameter, you will need to update the tag. Reference `EnviromentType` in the tag property.
 
+```yaml
     Tags:
       - Key: Name
         Value: !Join [ '-', [ !Ref EnvironmentType, webserver ] ]
+```
 
 #### 5. Finally, Deploy the solution
 
@@ -129,25 +138,27 @@ Don't forget to add `Dev` to the list of allowed values for the `EnvironmentType
 
 {{%expand "Expand to see the solution" %}}
 
-    Parameters:
-      EnvironmentType:
-        Description: 'Specify the Environment type of the stack.'
-        Type: String
-        Default: Test
-        AllowedValues:
-          - Dev
-          - Test
-          - Prod
-        ConstraintDescription: 'Specify either Dev, Test or Prod.'
+```yaml
+Parameters:
+  EnvironmentType:
+    Description: 'Specify the Environment type of the stack.'
+    Type: String
+    Default: Test
+    AllowedValues:
+      - Dev
+      - Test
+      - Prod
+    ConstraintDescription: 'Specify either Dev, Test or Prod.'
 
-    Mappings:
-      EnvironmentToInstanceType: # Map Name
-        Dev:
-          InstanceType: t2.nano
-        Test: # Top level key
-          InstanceType: t2.micro # Second level key
-        Prod:
-          InstanceType: t2.small
+Mappings:
+  EnvironmentToInstanceType: # Map Name
+    Dev:
+      InstanceType: t2.nano
+    Test: # Top level key
+      InstanceType: t2.micro # Second level key
+    Prod:
+      InstanceType: t2.small
+```
 
 See `code/20-cloudformation-features/06-lab04-Mapping-Solution.yaml` for the full solution.
 

--- a/workshop/content/30-workshop-part-01/20-cloudformation-features/400-lab-05-outputs.md
+++ b/workshop/content/30-workshop-part-01/20-cloudformation-features/400-lab-05-outputs.md
@@ -14,12 +14,14 @@ Furthermore, output values can be imported into other stacks. These are known as
 ##### YAML Syntax:
 The _Outputs_ section consists of the key name `Outputs`, followed by a colon.
 
-    Outputs:
-      Logical ID:
-        Description: Information about the value
-        Value: Value to return
-        Export:
-          Name: Value to export
+```yaml
+Outputs:
+  Logical ID:
+    Description: Information about the value
+    Value: Value to return
+    Export:
+      Name: Value to export
+```
 
 {{% notice note %}}
 You can declare a maximum of 60 outputs in a template.
@@ -41,11 +43,13 @@ In this Lab, you will:
     To get the _PublicDnsName_ of the instance, you will need to use `Fn::GetAtt` intrinsic function. Let's first check the [AWS Documentation](https://docs.aws.amazon.com/en_pv/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#aws-properties-ec2-instance-return-values) for available attributes. You can see that _PublicDnsName_ is valid return value for `Fn::GetAtt` function.
 
     Add the section below to your template:
-
-       Outputs:
-         EC2PublicDNS:
-           Description: 'Public DNS of EC2 instance'
-           Value: !GetAtt WebServerInstance.PublicDnsName
+    
+    ```yaml
+    Outputs:
+      EC2PublicDNS:
+        Description: 'Public DNS of EC2 instance'
+        Value: !GetAtt WebServerInstance.PublicDnsName
+   ```
 
 1. Go to the AWS console and update your stack with a new template.
 {{%expand "How do I update a Stack?" %}}
@@ -71,30 +75,32 @@ Check out the AWS Documentation for [AWS::EC2::EIP resource](https://docs.aws.am
 
 {{%expand "Want to see the solution?" %}}
 
-    Resources:
-      WebServerInstance:
-        Type: AWS::EC2::Instance
-        Properties:
-          ImageId: !Ref AmiID
-          InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
-          Tags:
-            - Key: Name
-              Value: !Join [ '-', [ !Ref EnvironmentType, webserver ] ]
+```yaml
+Resources:
+  WebServerInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref AmiID
+      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      Tags:
+        - Key: Name
+          Value: !Join [ '-', [ !Ref EnvironmentType, webserver ] ]
 
-      WebServerEIP:
-        Type: 'AWS::EC2::EIP'
-        Properties:
-          Domain: vpc
-          InstanceId: !Ref WebServerInstance
+  WebServerEIP:
+    Type: 'AWS::EC2::EIP'
+    Properties:
+      Domain: vpc
+      InstanceId: !Ref WebServerInstance
 
-    Outputs:
-      WebServerPublicDNS:
-        Description: 'Public DNS of EC2 instance'
-        Value: !GetAtt WebServerInstance.PublicDnsName
+Outputs:
+  WebServerPublicDNS:
+    Description: 'Public DNS of EC2 instance'
+    Value: !GetAtt WebServerInstance.PublicDnsName
 
-      WebServerElasticIP:
-        Description: 'Elastic IP assigned to EC2'
-        Value: !Ref WebServerEIP
+  WebServerElasticIP:
+    Description: 'Elastic IP assigned to EC2'
+    Value: !Ref WebServerEIP
+```
 {{% /expand %}}
 
 ---

--- a/workshop/content/30-workshop-part-01/30-launching-ec2/100-lab-06-ami.md
+++ b/workshop/content/30-workshop-part-01/30-launching-ec2/100-lab-06-ami.md
@@ -20,10 +20,12 @@ In this Lab, you will learn:
 1. Open the `01-lab06-SSM.yaml` file.
 1. Update the `AmiID` parameter to:
 
-       AmiID:
-         Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-         Description: The ID of the AMI.
-         Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+    ```yaml
+      AmiID:
+        Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+        Description: The ID of the AMI.
+        Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+   ```
 
 Go to the AWS console and update your stack with a new template.
 

--- a/workshop/content/30-workshop-part-01/30-launching-ec2/200-lab-07-session-manager.md
+++ b/workshop/content/30-workshop-part-01/30-launching-ec2/200-lab-07-session-manager.md
@@ -51,44 +51,50 @@ You can proceed to the next step as SSM Agent is pre-installed on Amazon Linux A
 #### 2. Create an IAM role for the EC2 instance
 The AWS managed policy, `AmazonSSMManagedInstanceCore`, allows an instance to use AWS Systems Manager service core functionality. This will allow you to connect to the EC2 instance using Systems Manager Session Manager.
 
-    SSMIAMRole:
-      Type: AWS::IAM::Role
-      Properties:
-        AssumeRolePolicyDocument:
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - ec2.amazonaws.com
-              Action:
-                - sts:AssumeRole
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+```yaml
+  SSMIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+```
 
 #### 3. Create an IAM Instance Profile
 
 Create Instance profile resource.
 
-    WebServerInstanceProfile:
-      Type: AWS::IAM::InstanceProfile
-      Properties:
-        Path: /
-        Roles:
-          - !Ref SSMIAMRole
+```yaml
+  WebServerInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref SSMIAMRole
+```
 
 #### 4. Attach the IAM Instance Profile to an Amazon EC2 Instance
 
 Attach the role to the instance with `IamInstanceProfile` property.
 
-    WebServerInstance:
-      Type: AWS::EC2::Instance
-      Properties:
-        IamInstanceProfile: !Ref WebServerInstanceProfile
-        ImageId: !Ref AmiID
-        InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
-        Tags:
-          - Key: Name
-            Value: !Join [ '-', [ !Ref EnvironmentType, Web Server ] ]
+```yaml
+  WebServerInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      IamInstanceProfile: !Ref WebServerInstanceProfile
+      ImageId: !Ref AmiID
+      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      Tags:
+        - Key: Name
+          Value: !Join [ '-', [ !Ref EnvironmentType, Web Server ] ]
+```
 
 {{% notice note %}}
 You can attach the instance profile to the new Amazon EC2 instances at launch time, or to existing Amazon EC2 instances.
@@ -129,7 +135,9 @@ Review the AWS documentation for [Instance Metadata and User Data](https://docs.
 {{%expand "Want to see the solution?" %}}
 Pate the following command inside the instance terminal:
 
-    curl http://169.254.169.254/latest/meta-data/ami-id
+```
+curl http://169.254.169.254/latest/meta-data/ami-id
+```
 
 ![ssm-sm](../ssm-sm-1.gif)
 {{% /expand %}}

--- a/workshop/content/40-workshop-part-02/10-nested-stacks/100-lab-10-nested-stacks.md
+++ b/workshop/content/40-workshop-part-02/10-nested-stacks/100-lab-10-nested-stacks.md
@@ -40,13 +40,15 @@ To reference a CloudFormation stack in your template, use the `AWS::CloudFormati
 
 It looks like this:
 
-    Resources:
-      NestedStackExample
-        Type: AWS::CloudFormation::Stack
-          Properties:
-            TemplateURL: 'Path/To/Template'
-            Parameters:
-              ExampleKey: ExampleValue
+```yaml
+Resources:
+  NestedStackExample:
+    Type: AWS::CloudFormation::Stack
+      Properties:
+        TemplateURL: 'Path/To/Template'
+        Parameters:
+          ExampleKey: ExampleValue
+```
 
 The `TemplateURL` property is used to reference the CloudFormation template that you wish to nest.
 
@@ -76,55 +78,59 @@ These parameters needs to be added to the main template so that they can be pass
 
 Copy the code below to the **Parameters** section of the `main.yaml` template.
 
-    AvailabilityZones:
-      Type: List<AWS::EC2::AvailabilityZone::Name>
-      Description: The list of Availability Zones to use for the subnets in the VPC. Select 2 AZs.
+```yaml
+  AvailabilityZones:
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+    Description: The list of Availability Zones to use for the subnets in the VPC. Select 2 AZs.
 
-    VPCName:
-      Type: String
-      Description: The name of the VPC.
-      Default: cfn-workshop-vpc
+  VPCName:
+    Type: String
+    Description: The name of the VPC.
+    Default: cfn-workshop-vpc
 
-    VPCCidr:
-      Type: String
-      Description: The CIDR block for the VPC.
-      AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-      ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-      Default: 10.0.0.0/16
+  VPCCidr:
+    Type: String
+    Description: The CIDR block for the VPC.
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/16
 
-    PublicSubnet1Cidr:
-      Type: String
-      Description: The CIDR block for the public subnet located in Availability Zone 1.
-      AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-      ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-      Default: 10.0.0.0/24
+  PublicSubnet1Cidr:
+    Type: String
+    Description: The CIDR block for the public subnet located in Availability Zone 1.
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.0.0/24
 
-    PublicSubnet2Cidr:
-      Type: String
-      Description: The CIDR block for the public subnet located in Availability Zone 2.
-      AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-      ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
-      Default: 10.0.1.0/24
+  PublicSubnet2Cidr:
+    Type: String
+    Description: The CIDR block for the public subnet located in Availability Zone 2.
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Default: 10.0.1.0/24
+```
 
 ##### 2. Create VPC resource in the main template
 In the code below, note that passing parameter values to resources works the same as if using a single standalone template. Make sure that parameter name in the main template matches parameter name in the VPC template.
 
 Add this code in the **Resources** section of the main template (`main.yaml`)
 
-    VpcStack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/vpc.yaml
-        TimeoutInMinutes: 20
-        Parameters:
-          AvailabilityZones:
-            Fn::Join:
-              - ','
-              - !Ref AvailabilityZones
-          VPCCidr: !Ref VPCCidr
-          VPCName: !Ref VPCName
-          PublicSubnet1Cidr: !Ref PublicSubnet1Cidr
-          PublicSubnet2Cidr: !Ref PublicSubnet2Cidr
+```yaml
+  VpcStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/vpc.yaml
+      TimeoutInMinutes: 20
+      Parameters:
+        AvailabilityZones:
+          Fn::Join:
+            - ','
+            - !Ref AvailabilityZones
+        VPCCidr: !Ref VPCCidr
+        VPCName: !Ref VPCName
+        PublicSubnet1Cidr: !Ref PublicSubnet1Cidr
+        PublicSubnet2Cidr: !Ref PublicSubnet2Cidr
+```
 
 ##### 3. Upload the VPC stack to S3
 
@@ -165,36 +171,40 @@ The **IAM role** template has been created for you. It is titled `iam.yaml`. Thi
 1. Open the `iam.yaml` file.
 1. Copy the code below to the **Resources** section of the template.
 
-       SSMIAMRole:
-         Type: AWS::IAM::Role
-         Properties:
-           AssumeRolePolicyDocument:
-             Statement:
-               - Effect: Allow
-                 Principal:
-                   Service:
-                     - ec2.amazonaws.com
-                 Action:
-                   - sts:AssumeRole
-           ManagedPolicyArns:
-             - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+```yaml
+  SSMIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 
-       WebServerInstanceProfile:
-         Type: AWS::IAM::InstanceProfile
-         Properties:
-           Path: /
-           Roles:
-             - !Ref SSMIAMRole
-
+  WebServerInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref SSMIAMRole
+```
 
 ##### 2. Create IAM resource in the main template
 Copy the code below to the **Resources** section of the `main.yaml` template.
 
-    IamStack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/iam.yaml
-        TimeoutInMinutes: 10
+```yaml
+  IamStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/iam.yaml
+      TimeoutInMinutes: 10
+```
+
 
 ##### 3. Upload the IAM stack to S3
 
@@ -230,25 +240,29 @@ Similarly to the VPC template, if you look into **Parameters** section of the `e
 
 Add the code below to the **Parameters** section of the `main.yaml` template:
 
-    EnvironmentType:
-      Description: 'Specify the Environment type of the stack.'
-      Type: String
-      Default: Test
-      AllowedValues:
-        - Dev
-        - Test
-        - Prod
-      ConstraintDescription: 'Specify either Dev, Test or Prod.'
+```yaml
+  EnvironmentType:
+    Description: 'Specify the Environment type of the stack.'
+    Type: String
+    Default: Test
+    AllowedValues:
+      - Dev
+      - Test
+      - Prod
+    ConstraintDescription: 'Specify either Dev, Test or Prod.'
+```
 
 ##### 2. Create EC2 resource in the main template
 
 Copy the code below to the **Resources** section of the `main.yaml` template.
 
-    EC2Stack:
-      Type: AWS::CloudFormation::Stack
-      Properties:
-        TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/ec2.yaml
-        TimeoutInMinutes: 20
+```yaml
+  EC2Stack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub https://${S3BucketName}.s3.amazonaws.com/ec2.yaml
+      TimeoutInMinutes: 20
+```
 
 ##### 3. Add EnvironmentType to the EC2 stack
 
@@ -277,6 +291,7 @@ Before you update your CloudFormation nested stack, there are a couple more thin
 
 1. Open up `ec2.yaml` file and create two parameters, `VpcId` and `SubnetId` in **Parameters** section of the template.
 
+    ```yaml
        VpcId:
          Type: AWS::EC2::VPC::Id
          Description: 'The VPC ID'
@@ -284,6 +299,7 @@ Before you update your CloudFormation nested stack, there are a couple more thin
        SubnetId:
          Type: AWS::EC2::Subnet::Id
          Description: 'The Subnet ID'
+   ```
 
 1. Next, locate the `WebServerSecurityGroup` resource.
 1. Add `VpcId` property and reference `VpcId` parameter in the `WebServerSecurityGroup` resource. Your security group resource should look like the code below.
@@ -309,16 +325,17 @@ Using the intrinsic function `!GetAtt`, CloudFormation can access the value from
 
 Add the code below to the `vpc.yaml` template.
 
-    Outputs:
-      VpcId:
-        Value: !Ref VPC
+```yaml
+Outputs:
+  VpcId:
+    Value: !Ref VPC
 
-      PublicSubnet1:
-        Value: !Ref VPCPublicSubnet1
+  PublicSubnet1:
+    Value: !Ref VPCPublicSubnet1
 
-      PublicSubnet2:
-        Value: !Ref VPCPublicSubnet2
-
+  PublicSubnet2:
+    Value: !Ref VPCPublicSubnet2
+```
 
 ##### 3. Add VpcId and SubnetId to **EC2Stack** stack
 
@@ -341,18 +358,22 @@ Add `VpcId` and `SubnetId` parameters to the EC2 stack in the `main.yaml` templa
 
 Open up `iam.yaml` and add the code below.
 
-    Outputs:
-      WebServerInstanceProfile:
-        Value: !Ref WebServerInstanceProfile
+```yaml
+Outputs:
+  WebServerInstanceProfile:
+    Value: !Ref WebServerInstanceProfile
+```
 
 ##### 5. Prepare the EC2 template
 
 1. Open up `ec2.yaml`
 1. Create the parameter `WebServerInstanceProfile` in the **Parameters** section of the template.
 
-       WebServerInstanceProfile:
-         Type: String
-         Description: 'Instance profile resource ID'
+```yaml
+   WebServerInstanceProfile:
+     Type: String
+     Description: 'Instance profile resource ID'
+```
 
 ##### 6. Add WebServerInstanceProfile to **EC2Stack** stack
 
@@ -374,10 +395,11 @@ Add the `WebServerInstanceProfile` parameter to the EC2 stack in the `main.yaml`
 
 Add the `WebsiteURL` to the `Outputs` section of the `main.yaml` template.
 
-    Outputs:
-      WebsiteURL:
-      Value: !GetAtt EC2Stack.Outputs.WebsiteURL
-
+```yaml
+Outputs:
+  WebsiteURL:
+  Value: !GetAtt EC2Stack.Outputs.WebsiteURL
+```
 
 ##### 8. Upload the EC2 stack to S3
 Before you can deploy the updated nested stack, you must update the templates in your S3 bucket that are referenced by the parent template, `main.yaml`.

--- a/workshop/content/40-workshop-part-02/20-layered-stack/100-lab-11-layered-stack.md
+++ b/workshop/content/40-workshop-part-02/20-layered-stack/100-lab-11-layered-stack.md
@@ -107,21 +107,23 @@ The concept of the **Layered Stack** is to use intrinsic functions to import pre
 
 Update the Parameters section to look as follows:
 
-    Parameters:
-      EnvironmentType:
-        Description: 'Specify the Environment type of the stack.'
-        Type: String
-        Default: Test
-        AllowedValues:
-          - Dev
-          - Test
-          - Prod
-        ConstraintDescription: 'Specify either Dev, Test or Prod.'
+```yaml
+Parameters:
+  EnvironmentType:
+    Description: 'Specify the Environment type of the stack.'
+    Type: String
+    Default: Test
+    AllowedValues:
+      - Dev
+      - Test
+      - Prod
+    ConstraintDescription: 'Specify either Dev, Test or Prod.'
 
-      AmiID:
-        Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-        Description: 'The ID of the AMI.'
-        Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+  AmiID:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Description: 'The ID of the AMI.'
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+```
 
 ##### 3. Update WebServerInstance resource
 
@@ -129,15 +131,17 @@ Next, we need to update the `Fn::Ref` in the template to import the exported val
 
 Update WebServerInstance resource in the Resources section of the `ec2.yaml` template:
 
-    WebServerInstance:
-      Type: AWS::EC2::Instance
-      {...}
-      Properties:
-        SubnetId: !ImportValue cfn-workshop-PublicSubnet1
-        IamInstanceProfile: !ImportValue cfn-workshop-WebServerInstanceProfile
-        ImageId: !Ref AmiID
-        InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
-      {...}
+```yaml
+  WebServerInstance:
+    Type: AWS::EC2::Instance
+    {...}
+    Properties:
+      SubnetId: !ImportValue cfn-workshop-PublicSubnet1
+      IamInstanceProfile: !ImportValue cfn-workshop-WebServerInstanceProfile
+      ImageId: !Ref AmiID
+      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+    {...}
+```
 
 ##### 4. Update the security group
 Finally, update the security group resource in a similar way. Update `WebServerSecurityGroup` resource in the **Resources** section of the `ec2.yaml` template.

--- a/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
+++ b/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
@@ -33,12 +33,13 @@ The project consists of:
 * One Lambda function.
 * Requirements file to install your function dependencies.
 
-      cfn101-workshop/code/60-package-and-deploy$ tree -F .
-      ├── infrastructure.template
-      └── lambda/
-          ├── lambda_function.py
-          └── requirements.txt
-
+```
+cfn101-workshop/code/60-package-and-deploy$ tree -F .
+├── infrastructure.template
+└── lambda/
+    ├── lambda_function.py
+    └── requirements.txt
+```
 
 
 #### Reference local files in CloudFormation template
@@ -79,7 +80,9 @@ Decide on the AWS region where you will be deploying your Cloudformation templat
 Make sure to replace the name of the bucket after `s3://` with a unique name!
 {{% /notice %}}
 
-    aws s3 mb s3://example-bucket-name --region eu-west-1
+```
+aws s3 mb s3://example-bucket-name --region eu-west-1
+```
 
 ##### 2. Install function dependencies
 
@@ -87,7 +90,9 @@ Our function depends on an external library [pytz](https://pypi.org/project/pytz
 
 From within a `code/60-package-and-deploy` directory run:
 
-    pip install pytz --target lambda
+```
+pip install pytz --target lambda
+```
 
 You should see the `pytz` package inside the `lambda/` folder.
 
@@ -137,7 +142,9 @@ You can notice that the `Code` property has been updated with two new attributes
 
 For completeness let’s also look what’s in the uploaded files. From the listing above we know the bucket and object name to download.
 
-    aws s3 cp s3://example-bucket-name/lambda-function/ce6c47b6c84d94bd207cea18e7d93458 .
+```
+aws s3 cp s3://example-bucket-name/lambda-function/ce6c47b6c84d94bd207cea18e7d93458 .
+```
 
 We know that `package` will ZIP files, so even there is no `.zip` extension you can still `unzip` it.
 


### PR DESCRIPTION
*Issue #, if available:* #92 

*Description of changes:*
This is intended to address #92 by marking all code blocks explicitly using backticks. 
I think it also makes it a lot clearer when editing, though, rather than counting on spaces.

I've visually inspected this change as it is rendered by github, but haven't attempted to reproduce the hugo output that is generating the site.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
