### PR TITLE
Fix v2.0.0 aws lambda invoke payload encoding issue

### DIFF
--- a/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
+++ b/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
@@ -228,7 +228,7 @@ From your terminal run:
 aws lambda invoke \
 --function-name cfn-workshop-python-function \
 --payload '{"time_zone": "Europe/London"}' \
---cli-binary-format raw-in-base64-out
+--cli-binary-format raw-in-base64-out \
 response.json
 ```
 

--- a/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
+++ b/workshop/content/40-workshop-part-02/30-package-and-deploy/100-lab-12-package-deploy.md
@@ -228,6 +228,7 @@ From your terminal run:
 aws lambda invoke \
 --function-name cfn-workshop-python-function \
 --payload '{"time_zone": "Europe/London"}' \
+--cli-binary-format raw-in-base64-out
 response.json
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
#90 
*Description of changes:*
This PR addresses an issue with `awscli` > 2.0.0 Since `awscli` 2.0.0 was released, payloads need to be base64 encoded when invoking a lambda. For more details see https://github.com/aws/aws-cli/issues/4968

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
