### PR TITLE
Fix the images paths in the 500-lab-resources.md

### DIFF
--- a/workshop/content/20-prerequisites/500-lab-resources.md
+++ b/workshop/content/20-prerequisites/500-lab-resources.md
@@ -14,8 +14,8 @@ The CloudFormation templates can be found in `code/` directory of the `cfn101-wo
 
     Or Download the ZIP file from [the Github repository page](https://github.com/aws-samples/cfn101-workshop):
 
-    ![git-download-png](../git-download.png)
+    ![git-download-png](git-download.png)
 
 1. Open the downloaded files in your code editor, as installed in [a previous step](../300-edit):
 
-    ![vscode-png](../vscode.png)
+    ![vscode-png](vscode.png)


### PR DESCRIPTION
Fix the images path with the same folder instead of the parent folder

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
