### PR TITLE
fixed names of referred keys

### DIFF
--- a/workshop/content/30-workshop-part-01/20-cloudformation-features/300-lab-04-mappings/_index.md
+++ b/workshop/content/30-workshop-part-01/20-cloudformation-features/300-lab-04-mappings/_index.md
@@ -11,7 +11,7 @@ This lab will introduce **[Mappings](https://docs.aws.amazon.com/AWSCloudFormati
 ![A diagram of the structure of a mappings section](mapping.png)
 
 Here is a simplified example of a Mappings section. It contains one Map, `AnExampleMapping`. \
-`AnExampleMapping` contains three top level keys, `Key01`, `Key02` and `Key03`. \
+`AnExampleMapping` contains three top level keys, `TopLevelKey01`, `TopLevelKey02` and `TopLevelKey03`. \
 Each top level key contains one or more `Key: Value` pairs.
 
 ```yaml


### PR DESCRIPTION
The three top level keys are TopLevelKey01, TopLevelKey02, and TopLevelKey03. The previously referred keys were actually sub-keys of TopLevelKey01.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
