### PR TITLE
Remove `--ignore-checks` from cfn-lint

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,16 +23,16 @@ jobs:
         restore-keys: |
 
     # Setup
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install python packages
       run: pip install -Ur requirements.txt
-    - name: Set up ruby 2.6
+    - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: '2.6'
+        ruby-version: 3.1
     - name: Install Ruby gems
       run: gem install cfn-nag
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -26,13 +26,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: 3.9
     - name: Install python packages
       run: pip install -Ur requirements.txt
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.0
     - name: Install Ruby gems
       run: gem install cfn-nag
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,6 +38,6 @@ jobs:
 
     # Run Tests
     - name: CloudFormation lint test
-      run: cfn-lint code/solutions/*.yaml
+      run: cfn-lint code/solutions/**/*.yaml --ignore-templates code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
     - name: CloudFormation nag test
       run: cfn_nag_scan --input-path code/solutions --ignore-fatal

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,15 +24,15 @@ jobs:
 
     # Setup
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10' # have to use quotes due to 0 being removed
     - name: Install python packages
       run: pip install -Ur requirements.txt
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.1
     - name: Install Ruby gems
       run: gem install cfn-nag
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
   - id: cfn-python-lint
     name: AWS CloudFormation Linter
     files: solutions/.*\.(yaml)$
-    args: [--ignore-checks=W3002]
     exclude: code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
 
 - repo: https://github.com/aws-cloudformation/rain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,9 @@ repos:
   - id: cfn-python-lint
     name: AWS CloudFormation Linter
     files: solutions/.*\.(yaml)$
-    exclude: code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
+    args: [
+      --ignore-templates=code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
+    ]
 
 - repo: https://github.com/aws-cloudformation/rain
   rev: v1.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,14 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: mixed-line-ending
-    args:
-    - --fix=lf
+    args: [
+      --fix=lf
+    ]
     exclude: /package-lock\.json$
   - id: check-added-large-files
-    args:
-    - --maxkb=1000
+    args: [
+      --maxkb=1000
+    ]
   - id: check-merge-conflict
 
 # Secrets
@@ -51,9 +53,10 @@ repos:
   rev: v2.11.1
   hooks:
     - id: pylint
-      args:
-        - --errors-only
-        - --disable=E0401
+      args: [
+        --errors-only
+        --disable=E0401
+      ]
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,19 @@ repos:
 
 # General
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-case-conflict
   - id: detect-private-key
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: mixed-line-ending
-    args: [
-      --fix=lf
-    ]
+    args:
+      - --fix=lf
     exclude: /package-lock\.json$
   - id: check-added-large-files
-    args: [
-      --maxkb=1000
-    ]
+    args:
+      - --maxkb=1000
   - id: check-merge-conflict
 
 # Secrets
@@ -32,14 +30,13 @@ repos:
 
 # CloudFormation
 - repo: https://github.com/aws-cloudformation/cfn-python-lint
-  rev: v0.54.3
+  rev: v0.58.0
   hooks:
   - id: cfn-python-lint
     name: AWS CloudFormation Linter
     files: solutions/.*\.(yaml)$
-    args: [
-      --ignore-templates=code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
-    ]
+    args:
+      - --ignore-templates=code/solutions/policy-as-code-with-guard/example_bucket_tests.yaml
 
 - repo: https://github.com/aws-cloudformation/rain
   rev: v1.2.0
@@ -50,20 +47,19 @@ repos:
 
 # Python
 - repo: https://github.com/pycqa/pylint
-  rev: v2.11.1
+  rev: v2.12.2
   hooks:
     - id: pylint
-      args: [
-        --errors-only
-        --disable=E0401
-      ]
+      args:
+        - --errors-only
+        - --disable=E0401
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.3
+  rev: 5.10.1
   hooks:
     - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 21.9b0
+  rev: 22.1.0
   hooks:
     - id: black


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
In this PR I have decided to remove `--ignore-checks` from the pre-commit file. There are two reasons for this:

1. The pre-commit cfn-lint checks diverge from the GitHub actions tests. By removing this, it will ensure consistency between these two.
2. These checks apply only to developers who setup their pre-commit localy, if that wasnt the case, and cfn-lint is run, the linter will show errors.

Going forward, there are times, specialy in the workshop, where it is needed to ignore some of the warnings and/or errors. I suggest to move cfn-lint rules to the template or resource based metadata, for example:

Inside the root level:
```yaml
Metadata:
  cfn-lint:
    config:
      regions:
        - us-east-1
        - us-east-2
      ignore_checks:
        - E2530
```

Inside a resource Metadata
```yaml
Resources:
  myInstance:
    Type: AWS::EC2::Instance
    Metadata:
      cfn-lint:
        config:
          ignore_checks:
            - E3030
    Properties:
      InstanceType: nt.x4superlarge
      ImageId: ami-abc1234
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
