### PR TITLE
Fix incorrect ImageID value

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 2.2.1
+current_version = 2.2.2
 commit = True
 tag = True

--- a/content/intermediate/templates/dynamic-references/index.md
+++ b/content/intermediate/templates/dynamic-references/index.md
@@ -54,7 +54,7 @@ Let’s get started! Choose to follow steps shown next:
     3. Locate the `AWS::EC2::Instance` resource type block in the template; update the template by appending, to properties in the `Properties` section, the `ImageId` property and a dynamic reference to your parameter:
 
        :::code{language=yaml showLineNumbers=false showCopyAction=true}
-       ImageId: '{{resolve\:ssm:/golden-images/amazon-linux-2}}'
+       ImageId: '{{resolve:ssm:/golden-images/amazon-linux-2}}'
        :::
 
 With the dynamic reference above, you describe the intent of resolving the `LATEST` version of your `/golden-images/amazon-linux-2` parameter during stack runtime.


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR fixes incorrect value for `ImageId`. The value had `\` character where it shouldn't be.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
