### PR TITLE
Fix s3 regex

### DIFF
--- a/code/solutions/nested-stacks/main.yaml
+++ b/code/solutions/nested-stacks/main.yaml
@@ -6,7 +6,7 @@ Parameters:
   S3BucketName:
     Description: S3 bucket name for the Nested Stacks. S3 bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
     Type: String
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-.]*[0-9a-zA-Z])*$
+    AllowedPattern: ^(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
     ConstraintDescription: Bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-).
 
   AvailabilityZones:

--- a/code/solutions/pseudo-parameters/pseudo-parameters.yaml
+++ b/code/solutions/pseudo-parameters/pseudo-parameters.yaml
@@ -12,10 +12,9 @@ Parameters:
   S3BucketNamePrefix:
     Description: The prefix to use for your S3 bucket
     Type: String
-    Default: my-demo-bucket
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    Default: cfn-workshop
+    AllowedPattern: ^(?!(^xn--|.$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
     ConstraintDescription: Bucket name prefix can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
-    MinLength: 3
 
 Resources:
   BasicParameter:

--- a/code/solutions/understanding-changesets/bucket.yaml
+++ b/code/solutions/understanding-changesets/bucket.yaml
@@ -6,6 +6,8 @@ Parameters:
   BucketName:
     Description: Name of the Amazon S3 bucket you wish to create
     Type: String
+    AllowedPattern: ^(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
+    ConstraintDescription: Bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-).
 
 Resources:
   MyS3Bucket:

--- a/code/solutions/understanding-changesets/changeset-challenge.yaml
+++ b/code/solutions/understanding-changesets/changeset-challenge.yaml
@@ -11,6 +11,8 @@ Parameters:
   BucketName:
     Description: Name of the Amazon S3 bucket you wish to create
     Type: String
+    AllowedPattern: ^(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
+    ConstraintDescription: Bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-).
 
 Resources:
   NewS3Bucket:

--- a/code/workspace/understanding-changesets/bucket.yaml
+++ b/code/workspace/understanding-changesets/bucket.yaml
@@ -6,6 +6,8 @@ Parameters:
   BucketName:
     Description: Name of the Amazon S3 bucket you wish to create
     Type: String
+    AllowedPattern: ^(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
+    ConstraintDescription: Bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-).
 
 Resources:
   MyS3Bucket:

--- a/code/workspace/understanding-changesets/changeset-challenge.yaml
+++ b/code/workspace/understanding-changesets/changeset-challenge.yaml
@@ -11,6 +11,8 @@ Parameters:
   BucketName:
     Description: Name of the Amazon S3 bucket you wish to create
     Type: String
+    AllowedPattern: ^(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
+    ConstraintDescription: Bucket name can include numbers, lowercase letters, uppercase letters, periods (.), and hyphens (-). It cannot start or end with a hyphen (-).
 
 Resources:
   NewS3Bucket:

--- a/content/basics/templates/pseudo-parameters/index.md
+++ b/content/basics/templates/pseudo-parameters/index.md
@@ -219,10 +219,9 @@ First, under the _Parameters_ section, add a template parameter `S3BucketNamePre
 S3BucketNamePrefix:
   Description: The prefix to use for your S3 bucket
   Type: String
-  Default: my-demo-bucket
-  AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+  Default: cfn-workshop
+  AllowedPattern: ^(?!(^xn--|.$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$
   ConstraintDescription: Bucket name prefix can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
-  MinLength: 3
 ```
 
 Then, add a `DemoBucket` resource under the _Resources_ section of the template.


### PR DESCRIPTION
## What does this PR do and why?

This PR fixes regex for `AllowedPatern ` in `Parameters` section of various templates. 

The new pattern has been inspired by [answer from StackOverflow](https://stackoverflow.com/questions/50480924/regex-for-s3-bucket-name) to accommodate AWS documentation on [Bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)


The pattern has been tested here https://regex101.com/r/pwH8T3/1 and test stack has been created to validate the pattern.
## Issue #, if available

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] Added/Updated documentation if applicable.
- [x] Pre-commit checks passed.
- [x] Lint and Nag checks passed.
- [ ] If releasing a new version, have you bumped the version `make version part=<major|minor|patch>`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
