### PR TITLE
Update GitHub action tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
-        cache: 'pip'
-    - run: python -m pip install -r requirements.txt
+        python-version: '3.x'
+        cache: 'pip' # caching pip dependencies
+    - run: pip install -r requirements.txt
     - uses: actions/cache@v3
       with:
-        path: ~/.cache/pre-commit/
+        path: ~/.cache/pre-commit/ # caching pre-commit environments
         key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,6 +20,6 @@ jobs:
     - run: pip install -r requirements.txt
     - uses: actions/cache@v3
       with:
-        path: ~/.cache/pre-commit/ # caching pre-commit environments
-        key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        path: ~/.cache/pre-commit # caching pre-commit environments
+        key: ${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml','~/.cache/pre-commit/*') }}
     - run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: pre-commit
 on:
   push:
     branches:
@@ -9,27 +9,16 @@ on:
     - edited
     - synchronize
 jobs:
-  unit_tests:
-    name: Unit tests
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
-    # Cache
-    - uses: actions/cache@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-
-    # Setup
-    - name: Set up Python
-      uses: actions/setup-python@v2
+        cache: 'pip'
+    - run: python -m pip install -r requirements.txt
+    - uses: actions/cache@v3
       with:
-        python-version: '3.10' # have to use quotes due to 0 being removed
-    - name: Install python packages
-      run: pip install -Ur requirements.txt
-
-    # Run Tests
-    - name: Run Pre-commit tests
-      run: pre-commit run --all-files
+        path: ~/.cache/pre-commit/
+        key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,6 +19,8 @@ jobs:
         cache: 'pip' # caching pip dependencies
     - run: pip install -r requirements.txt
     - uses: actions/cache@v3
+      env:
+        cache-name: pre-commit
       with:
         path: ~/.cache/pre-commit # caching pre-commit environments
         key: ${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml','~/.cache/pre-commit/*') }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,5 +23,5 @@ jobs:
         cache-name: pre-commit
       with:
         path: ~/.cache/pre-commit # caching pre-commit environments
-        key: ${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml','~/.cache/pre-commit/*') }}
+        key: ${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml','~/.cache/pre-commit/*') }} # the key is to cache both the pre-commit package and dependent hooks
     - run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ pre-commit: $(VENV_NAME)
 
 # Tests
 test: $(VENV_NAME)
-	$(VENV_NAME)/bin/pre-commit run --all-files
+	$(VENV_NAME)/bin/pre-commit run --show-diff-on-failure --color=always --all-files
 
 lint: $(VENV_NAME)
 	$(VENV_NAME)/bin/cfn-lint


### PR DESCRIPTION
## What does this PR do and why?

This PR tweaks the GH action tests we introduced in #238. Since we introduced pre-commit as the GH checks, the time for test to run increased from ~1 minute to somewhere between 3-8 minutes as pre-commit was installing environments from scratch every time the test run. By introducing cache for pre-commit, the tests time has been reduced back to ~1 minute, which should save everyone some time.

Changes to note:
- the action versions has been updated
- the test were renamed from unit to pre-commit as we use pre-commit only for our test use cases
- added caching for faster testing of the pre-commit

Tests:
I have run multiple GH tests to check reduced test time. More details and results in Actions tab.

## Issue #, if available

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.

- [ ] Added/Updated documentation if applicable.
- [x] Pre-commit checks passed.
- [x] Lint and Nag checks passed.
- [ ] If releasing a new version, have you bumped the version `make version part=<major|minor|patch>`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
