### PR TITLE
Added label for AmiID parameter in instrinsic-functions.yaml sources

### DIFF
--- a/code/solutions/intrinsic-functions.yaml
+++ b/code/solutions/intrinsic-functions.yaml
@@ -9,9 +9,12 @@ Metadata:
           default: Amazon EC2 Configuration
         Parameters:
           - InstanceType
+          - AmiID
     ParameterLabels:
       InstanceType:
         default: Type of EC2 Instance
+      AmiID:
+        default: Amazon Machine Image ID
 
 Parameters:
   InstanceType:

--- a/code/workspace/intrinsic-functions.yaml
+++ b/code/workspace/intrinsic-functions.yaml
@@ -9,10 +9,12 @@ Metadata:
           default: 'Amazon EC2 Configuration'
         Parameters:
           - InstanceType
-
+          - AmiID
     ParameterLabels:
       InstanceType:
         default: 'Type of EC2 Instance'
+      AmiID:
+        default: Amazon Machine Image ID
 
 Parameters:
   InstanceType:


### PR DESCRIPTION
## What does this PR do and why?

This PR proposes to fix `AmiID` parameter label to display as expected in scenario in Basics/Templates/Intrinsic functions.
Expected value is "Amazon Machine Image ID".

## PR acceptance checklist

Template source file in workspace folder fails cfn-lint as it is incomplete, with no `AmiID` parameter, as it has to be added as a part of the lab.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
