### PR TITLE
Bump database instance type from t2 to t3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 3.4.4
+current_version = 3.4.5
 commit = True
 tag = False

--- a/code/solutions/dynamic-references/database.yaml
+++ b/code/solutions/dynamic-references/database.yaml
@@ -31,7 +31,7 @@ Resources:
           - id: F80
           - id: F27
     Properties:
-      DBInstanceClass: db.t2.micro
+      DBInstanceClass: db.t3.micro
       AllocatedStorage: "20"
       Engine: mysql
       MasterUsername: !Ref DBUsername

--- a/code/workspace/dynamic-references/database.yaml
+++ b/code/workspace/dynamic-references/database.yaml
@@ -31,7 +31,7 @@ Resources:
           - id: F80
           - id: F27
     Properties:
-      DBInstanceClass: db.t2.micro
+      DBInstanceClass: db.t3.micro
       AllocatedStorage: "20"
       Engine: mysql
       MasterUsername: !Ref DBUsername


### PR DESCRIPTION
## What does this PR do and why?

This PR will bump the database version in dynamic-references/database.yaml to t3 as t2 is no longer available in at least some regions (including us-east-1, the recommended region for cfn workshop)

## Issue #265

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
