### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 3.4.5
+current_version = 3.4.6
 commit = True
 tag = False

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         python-version: '3.x'
         cache: 'pip' # caching pip dependencies
-    - run: pip install -r requirements.txt
+    - run: pip install pre-commit
     - uses: actions/cache@v3
       env:
         cache-name: pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
 
 # General
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: check-case-conflict
   - id: detect-private-key
@@ -30,13 +30,13 @@ repos:
 
 # CloudFormation
 - repo: https://github.com/aws-cloudformation/cfn-lint
-  rev: v0.79.7
+  rev: v1.20.2
   hooks:
   - id: cfn-lint-rc
     files: code/solutions/.*\.(ya?ml|template)$
 
 - repo: https://github.com/aws-cloudformation/rain
-  rev: v1.4.4
+  rev: v1.19.0
   hooks:
   - id: cfn-format
     files: code/solutions/.*\.(ya?ml|template)$
@@ -55,7 +55,7 @@ repos:
 
     # Python
 - repo: https://github.com/pycqa/pylint
-  rev: v3.0.0a7
+  rev: v3.3.2
   hooks:
     - id: pylint
       args:
@@ -63,19 +63,19 @@ repos:
         - --disable=E0401
 
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 24.10.0
   hooks:
     - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
     - id: isort
       args: ["--profile", "black"]
 
 # Shell check
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.9.0.5
+  rev: v0.10.0.1
   hooks:
     - id: shellcheck
       files: solutions/.*\.(sh)$

--- a/code/solutions/architecting-templates/application-blue-green.template
+++ b/code/solutions/architecting-templates/application-blue-green.template
@@ -99,22 +99,22 @@ Resources:
     Properties:
       DesiredCapacity: 2
       LaunchTemplate:
-        LaunchTemplateId: !Ref 'LaunchTemplate'
+        LaunchTemplateId: !Ref LaunchTemplate
         Version: !GetAtt LaunchTemplate.LatestVersionNumber
       MaxSize: 4
       MinSize: 2
       Tags:
         - Key: Name
           PropagateAtLaunch: true
-          Value: !Ref 'NameTagValue'
+          Value: !Ref NameTagValue
         - Key: AppName
           PropagateAtLaunch: true
-          Value: !Ref 'AppNameTagValue'
+          Value: !Ref AppNameTagValue
         - Key: Env
           PropagateAtLaunch: true
-          Value: !Ref 'Env'
+          Value: !Ref Env
       TargetGroupARNs:
-        - !Ref 'TargetGroup'
+        - !Ref TargetGroup
       VPCZoneIdentifier:
         - !ImportValue
           Fn::Sub: ${NetworkStackName}-PrivateSubnet1Id
@@ -126,9 +126,9 @@ Resources:
     Properties:
       DefaultActions:
         - Order: 1
-          TargetGroupArn: !Ref 'TargetGroup'
+          TargetGroupArn: !Ref TargetGroup
           Type: forward
-      LoadBalancerArn: !Ref 'LoadBalancer'
+      LoadBalancerArn: !Ref LoadBalancer
       Port: 80
       Protocol: HTTP
 
@@ -188,8 +188,8 @@ Resources:
                 ensureRunning: true
     Properties:
       LaunchTemplateData:
-        ImageId: !Ref 'LatestAmiId'
-        InstanceType: !Ref 'InstanceType'
+        ImageId: !Ref LatestAmiId
+        InstanceType: !Ref InstanceType
         SecurityGroupIds:
           - !ImportValue
             Fn::Sub: ${SecurityGroupStackName}-AppInstancesSecurityGroupId
@@ -203,11 +203,11 @@ Resources:
         - ResourceType: launch-template
           Tags:
             - Key: Name
-              Value: !Ref 'NameTagValue'
+              Value: !Ref NameTagValue
             - Key: AppName
-              Value: !Ref 'AppNameTagValue'
+              Value: !Ref AppNameTagValue
             - Key: Env
-              Value: !Ref 'Env'
+              Value: !Ref Env
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -224,11 +224,11 @@ Resources:
           Fn::Sub: ${NetworkStackName}-PublicSubnet2Id
       Tags:
         - Key: Name
-          Value: !Ref 'NameTagValue'
+          Value: !Ref NameTagValue
         - Key: AppName
-          Value: !Ref 'AppNameTagValue'
+          Value: !Ref AppNameTagValue
         - Key: Env
-          Value: !Ref 'Env'
+          Value: !Ref Env
       Type: application
 
   RecordSet:
@@ -242,9 +242,9 @@ Resources:
         Fn::Sub: ${HostedZoneStackName}-HostedZoneId
       Name: !ImportValue
         Fn::Sub: ${HostedZoneStackName}-HostedZoneName
-      SetIdentifier: !Sub '${AppNameTagValue} application managed with the ${AWS::StackName} stack.'
+      SetIdentifier: !Sub ${AppNameTagValue} application managed with the ${AWS::StackName} stack.
       Type: A
-      Weight: !Ref 'RecordSetWeight'
+      Weight: !Ref RecordSetWeight
 
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -259,11 +259,11 @@ Resources:
       Protocol: HTTP
       Tags:
         - Key: Name
-          Value: !Ref 'NameTagValue'
+          Value: !Ref NameTagValue
         - Key: AppName
-          Value: !Ref 'AppNameTagValue'
+          Value: !Ref AppNameTagValue
         - Key: Env
-          Value: !Ref 'Env'
+          Value: !Ref Env
       TargetType: instance
       UnhealthyThresholdCount: 2
       VpcId: !ImportValue
@@ -272,4 +272,4 @@ Resources:
 Outputs:
   AppUrl:
     Description: URL of the sample app.
-    Value: !Sub 'http://${LoadBalancer.DNSName}'
+    Value: !Sub http://${LoadBalancer.DNSName}

--- a/code/solutions/conditions/condition-resource-property.yaml
+++ b/code/solutions/conditions/condition-resource-property.yaml
@@ -26,4 +26,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref LatestAmiId
-      InstanceType: !If [IsProduction, t2.small, t2.micro]
+      InstanceType: !If
+        - IsProduction
+        - t2.small
+        - t2.micro

--- a/code/solutions/cross-stacks/ec2.yaml
+++ b/code/solutions/cross-stacks/ec2.yaml
@@ -110,12 +110,18 @@ Resources:
       SubnetId: !ImportValue cfn-workshop-PublicSubnet1
       IamInstanceProfile: !ImportValue cfn-workshop-WebServerInstanceProfile
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       SecurityGroupIds:
         - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: !Join [' ', [!Ref EnvironmentType, Web Server]]
+          Value: !Join
+            - ' '
+            - - !Ref EnvironmentType
+              - Web Server
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash -xe

--- a/code/solutions/cross-stacks/vpc.yaml
+++ b/code/solutions/cross-stacks/vpc.yaml
@@ -50,7 +50,9 @@ Resources:
     Properties:
       CidrBlock: !Ref PublicSubnet1Cidr
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !Ref AvailabilityZones]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -86,7 +88,9 @@ Resources:
     Properties:
       CidrBlock: !Ref PublicSubnet2Cidr
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [1, !Ref AvailabilityZones]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref AvailabilityZones
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name

--- a/code/solutions/dynamic-references/database.yaml
+++ b/code/solutions/dynamic-references/database.yaml
@@ -30,6 +30,10 @@ Resources:
         rules_to_suppress:
           - id: F80
           - id: F27
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W1011
     Properties:
       DBInstanceClass: db.t3.micro
       AllocatedStorage: "20"

--- a/code/solutions/dynamic-references/ec2-instance.yaml
+++ b/code/solutions/dynamic-references/ec2-instance.yaml
@@ -6,6 +6,9 @@ Resources:
   Instance:
     Type: AWS::EC2::Instance
     Properties:
-      AvailabilityZone: !Select ["0", !GetAZs ""]
+      AvailabilityZone: !Select
+        - 0
+        - !GetAZs
+          Ref: AWS::Region
       InstanceType: t2.micro
       ImageId: '{{resolve:ssm:/golden-images/amazon-linux-2}}'

--- a/code/solutions/dynamic-references/lambda-function.yaml
+++ b/code/solutions/dynamic-references/lambda-function.yaml
@@ -16,7 +16,7 @@ Resources:
                 - lambda.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
-        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Path: /
 
   DatabaseFunction:

--- a/code/solutions/dynamic-references/lambda-memory-size.yaml
+++ b/code/solutions/dynamic-references/lambda-memory-size.yaml
@@ -23,7 +23,7 @@ Resources:
                 - lambda.amazonaws.com
         Version: "2012-10-17"
       ManagedPolicyArns:
-        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Path: /
 
   HelloWorldFunction:

--- a/code/solutions/helper-scripts.yaml
+++ b/code/solutions/helper-scripts.yaml
@@ -130,12 +130,18 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref WebServerInstanceProfile
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       SecurityGroupIds:
         - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash -xe

--- a/code/solutions/intrinsic-functions.yaml
+++ b/code/solutions/intrinsic-functions.yaml
@@ -37,6 +37,9 @@ Resources:
       InstanceType: !Ref InstanceType
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref InstanceType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref InstanceType
+              - webserver
         - Key: InstanceType
           Value: !Sub ${InstanceType}

--- a/code/solutions/language-extensions/language-extensions-part1.yaml
+++ b/code/solutions/language-extensions/language-extensions-part1.yaml
@@ -11,7 +11,9 @@ Metadata:
 Parameters:
   DeletionPolicyParameter:
     Type: String
-    AllowedValues: [Delete, Retain]
+    AllowedValues:
+      - Delete
+      - Retain
     Default: Delete
 
   LatestAmiId:

--- a/code/solutions/language-extensions/language-extensions-part2.yaml
+++ b/code/solutions/language-extensions/language-extensions-part2.yaml
@@ -11,7 +11,9 @@ Metadata:
 Parameters:
   DeletionPolicyParameter:
     Type: String
-    AllowedValues: [Delete, Retain]
+    AllowedValues:
+      - Delete
+      - Retain
     Default: Delete
 
   LatestAmiId:
@@ -32,11 +34,15 @@ Resources:
           widgets:
             - type: metric
               x: 0
-              "y": 7
+              y: 7
               width: 3
               height: 3
               properties:
-                metrics: [[AWS/EC2, CPUUtilization, InstanceId, !Ref EC2Instance]]
+                metrics:
+                  - - AWS/EC2
+                    - CPUUtilization
+                    - InstanceId
+                    - !Ref EC2Instance
                 period: 300
                 stat: Average
                 region: !Ref AWS::Region

--- a/code/solutions/language-extensions/language-extensions-solution.yaml
+++ b/code/solutions/language-extensions/language-extensions-solution.yaml
@@ -11,7 +11,10 @@ Metadata:
 Parameters:
   DeletionPolicyParameter:
     Type: String
-    AllowedValues: [Delete, Retain, Snapshot]
+    AllowedValues:
+      - Delete
+      - Retain
+      - Snapshot
     Default: Delete
 
 Transform: AWS::LanguageExtensions
@@ -34,11 +37,17 @@ Resources:
           widgets:
             - type: metric
               x: 0
-              "y": 7
+              y: 7
               width: 3
               height: 3
               properties:
-                metrics: [[AWS/S3, NumberOfObjects, StorageType, AllStorageTypes, BucketName, !Ref S3Bucket]]
+                metrics:
+                  - - AWS/S3
+                    - NumberOfObjects
+                    - StorageType
+                    - AllStorageTypes
+                    - BucketName
+                    - !Ref S3Bucket
                 period: 86400
                 region: !Ref AWS::Region
                 title: S3 objects

--- a/code/solutions/looping-over-collections/s3-buckets.yaml
+++ b/code/solutions/looping-over-collections/s3-buckets.yaml
@@ -7,7 +7,9 @@ Transform: AWS::LanguageExtensions
 Resources:
   Fn::ForEach::S3Buckets:
     - S3BucketLogicalId
-    - [S3Bucket1, S3Bucket2, S3Bucket3]
+    - - S3Bucket1
+      - S3Bucket2
+      - S3Bucket3
     - ${S3BucketLogicalId}:
         Type: AWS::S3::Bucket
         Properties:

--- a/code/solutions/looping-over-collections/vpc.yaml
+++ b/code/solutions/looping-over-collections/vpc.yaml
@@ -62,10 +62,12 @@ Resources:
 
   Fn::ForEach::SubnetTypes:
     - SubnetType
-    - [Public, Private]
+    - - Public
+      - Private
     - Fn::ForEach::SubnetNumbers:
         - SubnetNumber
-        - ["1", "2"]
+        - - "1"
+          - "2"
         - ${SubnetType}Subnet${SubnetNumber}:
             Type: AWS::EC2::Subnet
             Properties:
@@ -74,7 +76,7 @@ Resources:
                   - SubnetAzIndexes
                   - !Ref SubnetType
                   - !Ref SubnetNumber
-                - !GetAZs ""
+                - !GetAZs
               CidrBlock: !FindInMap
                 - SubnetCidrs
                 - !Ref SubnetType
@@ -100,7 +102,8 @@ Resources:
 
   Fn::ForEach::DefaultRoutesForPublicSubnets:
     - SubnetNumber
-    - ["1", "2"]
+    - - "1"
+      - "2"
     - DefaultRouteForPublicSubnet${SubnetNumber}:
         DependsOn: VpcGatewayAttachment
         Type: AWS::EC2::Route
@@ -112,7 +115,8 @@ Resources:
 
   Fn::ForEach::NatGateways:
     - SubnetNumber
-    - ["1", "2"]
+    - - "1"
+      - "2"
     - Eip${SubnetNumber}:
         DependsOn: VpcGatewayAttachment
         Type: AWS::EC2::EIP
@@ -141,12 +145,14 @@ Resources:
 Outputs:
   Fn::ForEach::SubnetIdsOutputs:
     - SubnetType
-    - [Public, Private]
+    - - Public
+      - Private
     - Fn::ForEach::SubnetNumbers:
         - SubnetNumber
-        - ["1", "2"]
+        - - "1"
+          - "2"
         - ${SubnetType}Subnet${SubnetNumber}:
-            Description: !Sub 'The ID of ${SubnetType}Subnet${SubnetNumber}.'
+            Description: !Sub The ID of ${SubnetType}Subnet${SubnetNumber}.
             Export:
               Name: !Sub ${AWS::AccountId}-${SubnetType}Subnet${SubnetNumber}Id
             Value: !Ref

--- a/code/solutions/mappings.yaml
+++ b/code/solutions/mappings.yaml
@@ -42,7 +42,13 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver

--- a/code/solutions/multi-region-latest-ami.yaml
+++ b/code/solutions/multi-region-latest-ami.yaml
@@ -43,10 +43,16 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver
 
   WebServerEIP:
     Type: AWS::EC2::EIP

--- a/code/solutions/nested-stacks/ec2.yaml
+++ b/code/solutions/nested-stacks/ec2.yaml
@@ -122,12 +122,18 @@ Resources:
       SubnetId: !Ref SubnetId
       IamInstanceProfile: !Ref WebServerInstanceProfile
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       SecurityGroupIds:
         - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: !Join [' ', [!Ref EnvironmentType, Web Server]]
+          Value: !Join
+            - ' '
+            - - !Ref EnvironmentType
+              - Web Server
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash -xe

--- a/code/solutions/nested-stacks/vpc.yaml
+++ b/code/solutions/nested-stacks/vpc.yaml
@@ -46,7 +46,9 @@ Resources:
     Properties:
       CidrBlock: !Ref PublicSubnet1Cidr
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !Ref AvailabilityZones]
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -82,7 +84,9 @@ Resources:
     Properties:
       CidrBlock: !Ref PublicSubnet2Cidr
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [1, !Ref AvailabilityZones]
+      AvailabilityZone: !Select
+        - 1
+        - !Ref AvailabilityZones
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name

--- a/code/solutions/outputs.yaml
+++ b/code/solutions/outputs.yaml
@@ -42,10 +42,16 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver
 
   WebServerEIP:
     Type: AWS::EC2::EIP

--- a/code/solutions/package-and-deploy/infrastructure.template
+++ b/code/solutions/package-and-deploy/infrastructure.template
@@ -21,7 +21,7 @@ Resources:
     Properties:
       FunctionName: cfn-workshop-python-function
       Description: Python Function to return specific TimeZone time
-      Runtime: python3.8
+      Runtime: python3.12
       Role: !GetAtt LambdaBasicExecutionRole.Arn
       Handler: lambda_function.handler
       Code: lambda/

--- a/code/solutions/pseudo-parameters/pseudo-parameters.yaml
+++ b/code/solutions/pseudo-parameters/pseudo-parameters.yaml
@@ -45,14 +45,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: ssm:GetParameter
-                Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BasicParameter}'
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BasicParameter}
 
   DemoLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt DemoRole.Arn
-      Runtime: python3.8
+      Runtime: python3.12
       Code:
         ZipFile: |
           import boto3
@@ -64,4 +64,4 @@ Resources:
   DemoBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub '${S3BucketNamePrefix}-${AWS::Region}-${AWS::AccountId}'
+      BucketName: !Sub ${S3BucketNamePrefix}-${AWS::Region}-${AWS::AccountId}

--- a/code/solutions/resource-return-values/resource-return-values.yaml
+++ b/code/solutions/resource-return-values/resource-return-values.yaml
@@ -22,7 +22,7 @@ Resources:
             Effect: Deny
             Resource:
               - !GetAtt S3Bucket.Arn
-              - !Sub '${S3Bucket.Arn}/*'
+              - !Sub ${S3Bucket.Arn}/*
             Principal: '*'
             Condition:
               Bool:

--- a/code/solutions/session-manager.yaml
+++ b/code/solutions/session-manager.yaml
@@ -65,10 +65,16 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref WebServerInstanceProfile
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver
 
   WebServerEIP:
     Type: AWS::EC2::EIP

--- a/code/solutions/stacksets/example_network.yaml
+++ b/code/solutions/stacksets/example_network.yaml
@@ -69,7 +69,8 @@ Resources:
       VpcId: !Ref Vpc
       AvailabilityZone: !Select
         - 0
-        - !GetAZs ''
+        - !GetAZs
+          Ref: AWS::Region
       CidrBlock: !Ref AppPublicSubnet1Cidr
       MapPublicIpOnLaunch: true
       Tags:
@@ -82,7 +83,8 @@ Resources:
       VpcId: !Ref Vpc
       AvailabilityZone: !Select
         - 1
-        - !GetAZs ''
+        - !GetAZs
+          Ref: AWS::Region
       CidrBlock: !Ref AppPublicSubnet2Cidr
       MapPublicIpOnLaunch: true
       Tags:
@@ -110,12 +112,12 @@ Outputs:
 
   SubnetId1:
     Description: The subnet ID to use for public web servers
-    Value: !Ref 'PublicSubnet1'
+    Value: !Ref PublicSubnet1
     Export:
       Name: AWS-CloudFormationWorkshop-SubnetId1
 
   SubnetId2:
     Description: The subnet ID to use for public web servers
-    Value: !Ref 'PublicSubnet2'
+    Value: !Ref PublicSubnet2
     Export:
       Name: AWS-CloudFormationWorkshop-SubnetId2

--- a/code/solutions/stacksets/example_securitygroup.yaml
+++ b/code/solutions/stacksets/example_securitygroup.yaml
@@ -7,8 +7,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow http to client host
-      VpcId: !ImportValue
-        Fn::Sub: AWS-CloudFormationWorkshop-VpcId
+      VpcId: !ImportValue AWS-CloudFormationWorkshop-VpcId
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
@@ -23,6 +22,6 @@ Resources:
 Outputs:
   SecurityGroupId:
     Description: The security group ID to use to attach to instances.
-    Value: !Ref 'InstanceSecurityGroup'
+    Value: !Ref InstanceSecurityGroup
     Export:
       Name: AWS-CloudFormationWorkshop-SecurityGroupId

--- a/code/solutions/troubleshooting-provisioning-errors/sqs-queues.yaml
+++ b/code/solutions/troubleshooting-provisioning-errors/sqs-queues.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       FifoQueue: true
-      QueueName: !Sub '${QueueNamePrefix}-dead-letter.fifo'
+      QueueName: !Sub ${QueueNamePrefix}-dead-letter.fifo
 
   SourceQueue:
     Type: AWS::SQS::Queue
@@ -21,7 +21,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
         maxReceiveCount: 5
-      QueueName: !Sub '${QueueNamePrefix}-source.fifo'
+      QueueName: !Sub ${QueueNamePrefix}-source.fifo
 
   DeadLetterQueueParameter:
     Type: AWS::SSM::Parameter

--- a/code/solutions/update-behaviors-of-stack-resources/update-behaviors-of-stack-resources.yaml
+++ b/code/solutions/update-behaviors-of-stack-resources/update-behaviors-of-stack-resources.yaml
@@ -6,7 +6,10 @@ Parameters:
   InstanceType:
     Description: WebServer EC2 instance type
     Type: String
-    AllowedValues: [t2.micro, t2.small, t2.medium]
+    AllowedValues:
+      - t2.micro
+      - t2.small
+      - t2.medium
     Default: t2.micro
     ConstraintDescription: must be a valid EC2 instance type.
 

--- a/code/solutions/user-data.yaml
+++ b/code/solutions/user-data.yaml
@@ -65,12 +65,18 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref WebServerInstanceProfile
       ImageId: !Ref AmiID
-      InstanceType: !FindInMap [EnvironmentToInstanceType, !Ref EnvironmentType, InstanceType]
+      InstanceType: !FindInMap
+        - EnvironmentToInstanceType
+        - !Ref EnvironmentType
+        - InstanceType
       SecurityGroupIds:
         - !Ref WebServerSecurityGroup
       Tags:
         - Key: Name
-          Value: !Join ['-', [!Ref EnvironmentType, webserver]]
+          Value: !Join
+            - '-'
+            - - !Ref EnvironmentType
+              - webserver
       UserData: !Base64 |
         #!/bin/bash
         yum update -y


### PR DESCRIPTION
## What does this PR do and why?

This PR updates `pre-commit` hooks to the latest releases. You may notice lot of changes, however these are mainly down to formatting from `rain` hook. Changes to notice:
- the GitHub actions was installing `requirements.txt` which was completely unnecessary, we only need `pre-commit` for our action.
- suppress `cfn-lint` check "W1011 Use dynamic references over parameters for secrets"
- bump deprecated python 3.8 runtime (the runtime update in content will be addressed in subsequent PR)
- remove `Fn::Sub` from parameter import
- fix formatting for `!Select...!GetAzs`

## PR acceptance checklist

This checklist encourages us to confirm any changes have been analyzed to reduce risks in quality, performance, reliability, security, and maintainability.
- [x] Pre-commit checks passed.
- [x] Lint and Nag checks passed.
- [x] If releasing a new version, have you bumped the version `make version part=<major|minor|patch>`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
